### PR TITLE
readme update to include enabling ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install the following:
 
 ### Running
 
-Once minikube is running the two applications can be deployed using:
+Once minikube is running and ingress enabled with `minikube addons enable ingress`, the two applications can be deployed using:
 
 `kubectl apply -f kubernetes/grpcservice.yml`
 


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

Adds (to the readme) one command that was missing but required to get the full example running in k8s. 

## Changes

* One additional command for the readme

## Background Context

Without it, the curl command results in:

```
$ curl -v --header 'Host: superservice.com' $(minikube ip)/hello/donkey
* Trying 192.168.64.48...
* TCP_NODELAY set
* Connection failed
* connect to 192.168.64.48 port 80 failed: Connection refused
* Failed to connect to 192.168.64.48 port 80: Connection refused
* Closing connection 0
```

I _have_ signed the CLA